### PR TITLE
Make index.html link to views

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -3,17 +3,17 @@ const { basename, dirname, join } = require('path')
 const multipleEntry = require('react-app-rewire-multiple-entry')([
   {
     entry: 'src/pages/panel/index.tsx',
-    template: 'public/index.html',
+    template: 'src/template.html',
     outPath: 'panel.html',
   },
   {
     entry: 'src/pages/panel/index.tsx',
-    template: 'public/index.html',
+    template: 'src/template.html',
     outPath: 'mobile.html',
   },
   {
     entry: 'src/pages/overlay/index.tsx',
-    template: 'public/index.html',
+    template: 'src/template.html',
     outPath: 'video_overlay.html',
   }
 ]);

--- a/public/index.html
+++ b/public/index.html
@@ -1,44 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content=""
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>Alveus Ambassadors</title>
-  </head>
-  <body>
-    <script src="https://extension-files.twitch.tv/helper/v1/twitch-ext.min.js"></script>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <title>Alveus Ambassadors</title>
+</head>
+<body>
+<h1>Extension views:</h1>
+<ul>
+  <li><a href="video_overlay.html">Video overlay</a></li>
+  <li><a href="panel.html">Panel view</a></li>
+  <li><a href="mobile.html">Mobile view</a></li>
+</ul>
+</body>
 </html>

--- a/src/template.html
+++ b/src/template.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content=""
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/public" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Alveus Ambassadors</title>
+  </head>
+  <body>
+    <script src="https://extension-files.twitch.tv/helper/v1/twitch-ext.min.js"></script>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>


### PR DESCRIPTION
This makes the index.html a list of links to the various views (`video_overlay.html`, `panel.html` and `mobile.html`) and use `src/template.html` instead to generate the view htmls.

This makes it easier to open the views on the dev server not having to type in the paths.