### PR TITLE
Move core app logic to proper hooks/contexts

### DIFF
--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -9,26 +9,24 @@ import Overlay from './components/overlay/Overlay'
 import styles from './App.module.scss'
 
 // Hide the overlay after 5s of inactivity
-const timeout = 5000;
+const timeout = 5_000;
 
 export default function App() {
   // Show/hide the overlay based on mouse movement
-  const sleeping = useSleeping();
+  const { sleeping, wake, sleep, on: addSleepListener, off: removeSleepListener } = useSleeping();
   const appRef = useRef<HTMLDivElement>(null)
 
   // When the user interacts, show the overlay
-  const interacted = useCallback(() => {
-    sleeping.wake(timeout)
-  }, [sleeping.wake])
+  const interacted = useCallback(() => wake(timeout), [wake])
 
   // Hide the cursor when the user is idle
   const [, showCursor] = useHiddenCursor()
 
   // When the overlay is awoken, show the cursor
   useEffect(() => {
-    sleeping.on('wake', showCursor)
-    return () => sleeping.off('wake', showCursor)
-  }, [sleeping.on, sleeping.off, showCursor])
+    addSleepListener('wake', showCursor)
+    return () => removeSleepListener('wake', showCursor)
+  }, [addSleepListener, removeSleepListener, showCursor])
 
   // When a user scrolls, treat it as an interaction (but handle Firefox being weird)
   const scrollRef = useRef<[HTMLElement, number]|undefined>(undefined)
@@ -56,7 +54,7 @@ export default function App() {
 
   // Block sleeping hiding the overlay if dev toggle is on
   const settings = useStoredSettings()
-  let visibilityClass = sleeping.sleeping ? styles.hidden : styles.visible
+  let visibilityClass = sleeping ? styles.hidden : styles.visible
   if (process.env.NODE_ENV === 'development' && settings.disableOverlayHiding.value)
     visibilityClass = styles.visible
 
@@ -66,7 +64,7 @@ export default function App() {
       className={classes(styles.app, visibilityClass)}
       onMouseEnter={interacted}
       onMouseMove={interacted}
-      onMouseLeave={sleeping.sleep}
+      onMouseLeave={sleep}
     >
       <Overlay />
     </div>

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -8,14 +8,17 @@ import useSleeping from './hooks/useSleeping'
 import Overlay from './components/overlay/Overlay'
 import styles from './App.module.scss'
 
+// Hide the overlay after 5s of inactivity
+const timeout = 5000;
+
 export default function App() {
   // Show/hide the overlay based on mouse movement
   const sleeping = useSleeping();
   const appRef = useRef<HTMLDivElement>(null)
 
-  // When the user interacts, have a 5s timeout before hiding the overlay
+  // When the user interacts, show the overlay
   const interacted = useCallback(() => {
-    sleeping.wake(5000)
+    sleeping.wake(timeout)
   }, [sleeping.wake])
 
   // Hide the cursor when the user is idle

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -1,46 +1,31 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 
 import { classes } from '../../utils/classes'
 import useHiddenCursor from './hooks/useHiddenCursor'
 import useStoredSettings from './hooks/useStoredSettings'
+import useSleeping from './hooks/useSleeping'
 
 import Overlay from './components/overlay/Overlay'
 import styles from './App.module.scss'
 
 export default function App() {
-  // Hide the cursor when the user is idle
-  const [, showCursor] = useHiddenCursor()
-
   // Show/hide the overlay based on mouse movement
+  const sleeping = useSleeping();
   const appRef = useRef<HTMLDivElement>(null)
-  const sleepTimer = useRef<NodeJS.Timeout | undefined>(undefined)
-  const [sleeping, setSleeping] = useState(false)
-
-  // Allow children to know when we have been woken up
-  const [awoken, setAwoken] = useState<(() => void)[]>([])
-  const addAwoken = useCallback((callback: () => void) => {
-    setAwoken(current => [...current, callback])
-  }, [])
-  const removeAwoken = useCallback((callback: () => void) => {
-    setAwoken(current => current.filter(c => c !== callback))
-  }, [])
-  const awokenObj = useMemo(() => ({ add: addAwoken, remove: removeAwoken }), [addAwoken, removeAwoken])
-
-  // Wake the overlay for x milliseconds
-  const wake = useCallback((time: number) => {
-    setSleeping(false)
-    awoken.forEach(fn => fn())
-    if (sleepTimer.current) clearTimeout(sleepTimer.current)
-    sleepTimer.current = setTimeout(() => {
-      setSleeping(true)
-    }, time)
-  }, [awoken])
 
   // When the user interacts, have a 5s timeout before hiding the overlay
   const interacted = useCallback(() => {
-    wake(5000)
-    showCursor()
-  }, [wake, showCursor])
+    sleeping.wake(5000)
+  }, [sleeping.wake])
+
+  // Hide the cursor when the user is idle
+  const [, showCursor] = useHiddenCursor()
+
+  // When the overlay is awoken, show the cursor
+  useEffect(() => {
+    sleeping.on('wake', showCursor)
+    return () => sleeping.off('wake', showCursor)
+  }, [sleeping.on, sleeping.off, showCursor])
 
   // When a user scrolls, treat it as an interaction (but handle Firefox being weird)
   const scrollRef = useRef<[HTMLElement, number]|undefined>(undefined)
@@ -66,20 +51,9 @@ export default function App() {
     return () => node.removeEventListener("scroll", scrolled, true)
   }, [scrolled])
 
-  // Immediately sleep the overlay
-  const sleep = useCallback(() => {
-    setSleeping(true)
-    if (sleepTimer.current) clearTimeout(sleepTimer.current)
-  }, [])
-
-  // When we unmount, clear the sleep timer
-  useEffect(() => () => {
-    if (sleepTimer.current) clearTimeout(sleepTimer.current)
-  }, [])
-
   // Block sleeping hiding the overlay if dev toggle is on
   const settings = useStoredSettings()
-  let visibilityClass = sleeping ? styles.hidden : styles.visible
+  let visibilityClass = sleeping.sleeping ? styles.hidden : styles.visible
   if (process.env.NODE_ENV === 'development' && settings.disableOverlayHiding.value)
     visibilityClass = styles.visible
 
@@ -89,13 +63,9 @@ export default function App() {
       className={classes(styles.app, visibilityClass)}
       onMouseEnter={interacted}
       onMouseMove={interacted}
-      onMouseLeave={sleep}
+      onMouseLeave={sleeping.sleep}
     >
-      <Overlay
-        sleeping={sleeping}
-        awoken={awokenObj}
-        wake={wake}
-      />
+      <Overlay />
     </div>
   )
 }

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef } from 'react'
 
 import { classes } from '../../utils/classes'
 import useHiddenCursor from './hooks/useHiddenCursor'
-import useStoredSettings from './hooks/useStoredSettings'
+import useSettings from './hooks/useSettings'
 import useSleeping from './hooks/useSleeping'
 
 import Overlay from './components/overlay/Overlay'
@@ -53,7 +53,7 @@ export default function App() {
   }, [scrolled])
 
   // Block sleeping hiding the overlay if dev toggle is on
-  const settings = useStoredSettings()
+  const settings = useSettings()
   let visibilityClass = sleeping ? styles.hidden : styles.visible
   if (process.env.NODE_ENV === 'development' && settings.disableOverlayHiding.value)
     visibilityClass = styles.visible

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { typeSafeObjectEntries, typeSafeObjectFromEntries } from '../../utils/helpers'
 import { classes } from '../../utils/classes'
 
+import useHiddenCursor from './hooks/useHiddenCursor'
+
 import Overlay from './components/overlay/Overlay'
 import styles from './App.module.scss'
 
@@ -35,6 +37,9 @@ export type Settings = {
 }
 
 export default function App() {
+  // Hide the cursor when the user is idle
+  const [, showCursor] = useHiddenCursor()
+
   const [storedSettings, setStoredSettings] = useState<StoredSettings>(() => {
     // Load settings from local storage, merging with defaults
     const storage = JSON.parse(localStorage.getItem("settings") || "{}")
@@ -91,13 +96,8 @@ export default function App() {
   // When the user interacts, have a 5s timeout before hiding the overlay
   const interacted = useCallback(() => {
     wake(5000)
-  }, [wake])
-
-  // Hide the cursor when sleeping
-  useEffect(() => {
-    if (sleeping) document.documentElement.style.cursor = 'none'
-    else document.documentElement.style.removeProperty('cursor')
-  }, [sleeping])
+    showCursor()
+  }, [wake, showCursor])
 
   // When a user scrolls, treat it as an interaction (but handle Firefox being weird)
   const scrollRef = useRef<[HTMLElement, number]|undefined>(undefined)

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -19,6 +19,9 @@ import SettingsOverlay from './settings/Settings'
 
 import styles from './overlay.module.scss'
 
+// Show command-triggered popups for 8s
+const commandTimeout = 8000
+
 const overlayOptions = [
   {
     key: 'welcome',
@@ -60,7 +63,6 @@ export default function Overlay() {
   const [visibleOption, setVisibleOption] = useState<OverlayKey>()
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
   const awakingRef = useRef(false)
-  const commandDelay = 8000
 
   // When a chat command is run, wake the overlay
   useChatCommand(useCallback((command: string) => {
@@ -75,13 +77,13 @@ export default function Overlay() {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
       timeoutRef.current = setTimeout(() => {
         setVisibleOption(undefined)
-      }, commandDelay)
+      }, commandTimeout)
 
       // Track that we're waking up, so that we don't immediately clear the timeout, and wake the overlay
       awakingRef.current = true
-      sleeping.wake(commandDelay)
+      sleeping.wake(commandTimeout)
     }
-  }, [settings.disableChatPopup, commandDelay, sleeping.wake]))
+  }, [settings.disableChatPopup, commandTimeout, sleeping.wake]))
 
   // Ensure we clean up the timer when we unmount
   useEffect(() => () => {
@@ -89,6 +91,7 @@ export default function Overlay() {
   }, [])
 
   // If the user interacts with the overlay, clear the auto-dismiss timer
+  // Except if we just triggered this wake, in which case we want to ignore it
   useEffect(() => {
     const callback = () => {
       if (awakingRef.current) awakingRef.current = false

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -5,7 +5,7 @@ import Buttons from '../buttons/Buttons'
 import useChatCommand from '../../../../utils/chatCommand'
 import { isAmbassadorKey, type AmbassadorKey } from '../../../../utils/ambassadors'
 import { classes } from '../../../../utils/classes'
-import useStoredSettings from '../../hooks/useStoredSettings'
+import useSettings from '../../hooks/useSettings'
 import useSleeping from '../../hooks/useSleeping'
 
 import WelcomeIcon from '../../../../assets/overlay/welcome.png'
@@ -56,7 +56,7 @@ export interface OverlayOptionProps {
 }
 
 export default function Overlay() {
-  const settings = useStoredSettings()
+  const settings = useSettings()
   const { sleeping, wake, on: addSleepListener, off: removeSleepListener } = useSleeping()
 
   const [commandAmbassador, setCommandAmbassador] = useState<AmbassadorKey>()

--- a/src/pages/overlay/components/overlay/settings/Settings.tsx
+++ b/src/pages/overlay/components/overlay/settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { typeSafeObjectEntries } from '../../../../../utils/helpers'
-import useStoredSettings from '../../../hooks/useStoredSettings'
+import useSettings from '../../../hooks/useSettings'
 
 import Card from '../../card/Card'
 import Toggle from '../../toggle/Toggle'
@@ -9,7 +9,7 @@ import styles from './settings.module.scss'
 
 export default function Settings(props: OverlayOptionProps) {
   const { className } = props
-  const settings = useStoredSettings()
+  const settings = useSettings()
 
   return (
     <Card className={className} title="Extension Settings">

--- a/src/pages/overlay/components/overlay/settings/Settings.tsx
+++ b/src/pages/overlay/components/overlay/settings/Settings.tsx
@@ -1,4 +1,6 @@
 import { typeSafeObjectEntries } from '../../../../../utils/helpers'
+import useStoredSettings from '../../../hooks/useStoredSettings'
+
 import Card from '../../card/Card'
 import Toggle from '../../toggle/Toggle'
 import type { OverlayOptionProps } from '../Overlay'
@@ -6,12 +8,13 @@ import type { OverlayOptionProps } from '../Overlay'
 import styles from './settings.module.scss'
 
 export default function Settings(props: OverlayOptionProps) {
-  const { context, className } = props
+  const { className } = props
+  const settings = useStoredSettings()
 
   return (
     <Card className={className} title="Extension Settings">
       <ul className={styles.settings}>
-        {typeSafeObjectEntries(context.settings).map(([key, setting]) => {
+        {typeSafeObjectEntries(settings).map(([key, setting]) => {
           if (setting.devOnly && process.env.NODE_ENV !== 'development') return null
 
           return (

--- a/src/pages/overlay/hooks/useHiddenCursor.ts
+++ b/src/pages/overlay/hooks/useHiddenCursor.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const useHiddenCursor = () => {
+  // Hide the cursor if the user is inactive on the whole page
+  const timer = useRef<NodeJS.Timeout | undefined>(undefined)
+  const [hidden, setHidden] = useState(false)
+
+  // Any interaction shows the cursor for 5 seconds
+  const show = useCallback(() => {
+    setHidden(false)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      setHidden(true)
+    }, 5000)
+  }, [])
+
+  // Show the cursor as soon as the user interacts with the page
+  useEffect(() => {
+    document.addEventListener('mouseenter', show)
+    document.addEventListener('mousemove', show)
+
+    return () => {
+      document.removeEventListener('mouseenter', show)
+      document.removeEventListener('mousemove', show)
+    }
+  }, [show])
+
+  // Hide the cursor when inactive (not sleeping, as that happens on mouse exit)
+  useEffect(() => {
+    if (hidden) document.documentElement.style.cursor = 'none'
+    else document.documentElement.style.removeProperty('cursor')
+  }, [hidden])
+
+  // When we unmount, clear the sleep timer
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
+
+  // Expose the state and the active function
+  return [hidden, show] as [boolean, () => void]
+}
+
+export default useHiddenCursor

--- a/src/pages/overlay/hooks/useHiddenCursor.ts
+++ b/src/pages/overlay/hooks/useHiddenCursor.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import useIntelligentTimer from './useIntelligentTimer'
 
 // Hide the cursor after 5s of inactivity
-const timeout = 5000;
+const timeout = 5_000;
 
 const useHiddenCursor = () => {
   // Hide the cursor if the user is inactive on the whole page

--- a/src/pages/overlay/hooks/useIntelligentTimer.ts
+++ b/src/pages/overlay/hooks/useIntelligentTimer.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+const useIntelligentTimer = () => {
+  const current = useRef<NodeJS.Timeout | undefined>(undefined)
+  const end = useRef<number | undefined>(undefined)
+
+  const start = useCallback((callback: () => void, time: number) => {
+    // If the requested time is less than the current time, do nothing
+    const newEnd = Date.now() + time
+    if (end.current && newEnd < end.current) return
+
+    // If there's a timer, clear it
+    if (current.current) clearTimeout(current.current)
+
+    // Start the new timer
+    end.current = newEnd
+    current.current = setTimeout(() => {
+      callback()
+      end.current = undefined
+    }, time)
+  }, [])
+
+  const stop = useCallback(() => {
+    if (current.current) clearTimeout(current.current)
+    end.current = undefined
+  }, [])
+
+  useEffect(() => () => {
+    if (current.current) clearTimeout(current.current)
+  }, [])
+
+  return [start, stop] as [typeof start, typeof stop]
+}
+
+export default useIntelligentTimer

--- a/src/pages/overlay/hooks/useSettings.tsx
+++ b/src/pages/overlay/hooks/useSettings.tsx
@@ -64,10 +64,10 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
   return <context.Provider value={obj}>{children}</context.Provider>
 }
 
-const useStoredSettings = () => {
+const useSettings = () => {
   const ctx = useContext(context)
-  if (!ctx) throw new Error("useStoredSettings must be used within a SettingsProvider")
+  if (!ctx) throw new Error("useSettings must be used within a SettingsProvider")
   return ctx
 }
 
-export default useStoredSettings
+export default useSettings

--- a/src/pages/overlay/hooks/useSleeping.tsx
+++ b/src/pages/overlay/hooks/useSleeping.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
 
 import useIntelligentTimer from './useIntelligentTimer'
 
@@ -19,7 +19,7 @@ export type Sleeping = {
 
 const context = createContext<Sleeping | undefined>(undefined)
 
-export const SleepingProvider = ({ children }: { children: React.ReactNode }) => {
+export const SleepingProvider = ({ children }: { children: ReactNode }) => {
   const [startTimer, stopTimer] = useIntelligentTimer()
   const [sleeping, setSleeping] = useState(false)
 

--- a/src/pages/overlay/hooks/useSleeping.tsx
+++ b/src/pages/overlay/hooks/useSleeping.tsx
@@ -1,0 +1,70 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+
+const events = ['wake', 'sleep'] as const
+type Event = typeof events[number]
+
+export type Sleeping = {
+  sleeping: boolean,
+  wake: (time: number) => void,
+  sleep: () => void,
+  on: (event: Event, fn: () => void) => void,
+  off: (event: Event, fn: () => void) => void,
+}
+
+const context = createContext<Sleeping | undefined>(undefined)
+
+export const SleepingProvider = ({ children }: { children: React.ReactNode }) => {
+  const timer = useRef<NodeJS.Timeout | undefined>(undefined)
+  const [sleeping, setSleeping] = useState(false)
+
+  // Allow subscriptions to wake/sleep events
+  // This allows logic to know when the overlay was re-awoken, even if it was already awake
+  const [callbacks, setCallbacks] = useState<{ [k in Event]: (() => void)[] }>(events.reduce((prev, event) => ({ ...prev, [event]: [] }), {} as any))
+  const on = useCallback<Sleeping['on']>((event, fn) => {
+    setCallbacks(prev => ({ ...prev, [event]: [...prev[event], fn] }))
+  }, [])
+  const off = useCallback<Sleeping['off']>((event, fn) => {
+    setCallbacks(prev => ({ ...prev, [event]: prev[event].filter(f => f !== fn) }))
+  }, [])
+
+  // Wake the overlay for x milliseconds
+  const wake = useCallback((time: number) => {
+    setSleeping(false)
+    callbacks.wake.forEach(fn => fn())
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      setSleeping(true)
+    }, time)
+  }, [callbacks.wake])
+
+  // Immediately sleep the overlay
+  const sleep = useCallback(() => {
+    setSleeping(true)
+    callbacks.sleep.forEach(fn => fn())
+    if (timer.current) clearTimeout(timer.current)
+  }, [callbacks.sleep])
+
+  // When we unmount, clear the sleep timer
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
+
+  // Expose the full object for sleeping
+  const obj = useMemo(() => ({
+    sleeping,
+    wake,
+    sleep,
+    on,
+    off,
+  }), [sleeping, wake, sleep, on, off])
+
+  return <context.Provider value={obj}>{children}</context.Provider>
+}
+
+const useSleeping = () => {
+  const ctx = useContext(context)
+  if (!ctx) throw new Error("useSleeping must be used within a SleepingProvider")
+  return ctx
+}
+
+export default useSleeping

--- a/src/pages/overlay/hooks/useStoredSettings.tsx
+++ b/src/pages/overlay/hooks/useStoredSettings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
 
 import { typeSafeObjectEntries, typeSafeObjectFromEntries } from '../../../utils/helpers'
 
@@ -32,7 +32,7 @@ export type Settings = {
 
 const context = createContext<Settings | undefined>(undefined)
 
-export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+export const SettingsProvider = ({ children }: { children: ReactNode }) => {
   const [stored, setStored] = useState<StoredSettings>(() => {
     // Load settings from local storage on mount, merging with defaults
     const storage = JSON.parse(localStorage.getItem('settings') || '{}')

--- a/src/pages/overlay/hooks/useStoredSettings.tsx
+++ b/src/pages/overlay/hooks/useStoredSettings.tsx
@@ -1,0 +1,73 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+
+import { typeSafeObjectEntries, typeSafeObjectFromEntries } from '../../../utils/helpers'
+
+const settings = {
+  disableChatPopup: {
+    title: 'Prevent Mod-triggered Card Popups',
+    type: 'boolean',
+    process: (value: any) => !!value,
+    devOnly: false,
+  },
+  disableOverlayHiding: {
+    title: '(DEV) Prevent app hiding automatically',
+    type: 'boolean',
+    process: (value: any) => !!value,
+    devOnly: true,
+  }
+}
+
+type SettingsKey = keyof typeof settings
+
+type StoredSettings = {
+  [key in SettingsKey]: ReturnType<typeof settings[key]['process']>
+}
+
+export type Settings = {
+  [key in SettingsKey]: typeof settings[key] & {
+    value: StoredSettings[key]
+    change: (value: StoredSettings[key]) => void
+  }
+}
+
+const context = createContext<Settings | undefined>(undefined)
+
+export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [stored, setStored] = useState<StoredSettings>(() => {
+    // Load settings from local storage on mount, merging with defaults
+    const storage = JSON.parse(localStorage.getItem('settings') || '{}')
+    return typeSafeObjectEntries(settings)
+      .reduce((acc, [key, value]) => ({ ...acc, [key]: value.process(storage[key]) }), {} as StoredSettings)
+  })
+
+  // Save settings to local storage when they change
+  useEffect(() => {
+    localStorage.setItem('settings', JSON.stringify(stored))
+  }, [stored])
+
+  // Change the value of a setting
+  const change = useCallback(<Key extends SettingsKey>(key: Key, value: StoredSettings[Key]) => {
+    setStored(current => ({ ...current, [key]: value }))
+  }, [])
+
+  // Expose a full object for the settings
+  const obj = useMemo<Settings>(() => typeSafeObjectFromEntries(typeSafeObjectEntries(settings)
+    .map(([key, value]) => [
+      key,
+      {
+        ...value,
+        value: stored[key],
+        change: (value: any) => change(key, value),
+      }
+    ])), [stored, change])
+
+  return <context.Provider value={obj}>{children}</context.Provider>
+}
+
+const useStoredSettings = () => {
+  const ctx = useContext(context)
+  if (!ctx) throw new Error("useStoredSettings must be used within a SettingsProvider")
+  return ctx
+}
+
+export default useStoredSettings

--- a/src/pages/overlay/index.tsx
+++ b/src/pages/overlay/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
-import { SettingsProvider } from './hooks/useStoredSettings';
+import { SettingsProvider } from './hooks/useSettings';
 import { SleepingProvider } from './hooks/useSleeping';
 import { bindTwitchAuth } from '../../utils/twitch-api';
 

--- a/src/pages/overlay/index.tsx
+++ b/src/pages/overlay/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 
 import App from './App';
 import { SettingsProvider } from './hooks/useStoredSettings';
+import { SleepingProvider } from './hooks/useSleeping';
 import { bindTwitchAuth } from '../../utils/twitch-api';
 
 import './index.scss';
@@ -14,7 +15,9 @@ const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
   <React.StrictMode>
     <SettingsProvider>
-      <App />
+      <SleepingProvider>
+        <App />
+      </SleepingProvider>
     </SettingsProvider>
   </React.StrictMode>
 );

--- a/src/pages/overlay/index.tsx
+++ b/src/pages/overlay/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import { SettingsProvider } from './hooks/useStoredSettings';
 import { bindTwitchAuth } from '../../utils/twitch-api';
 
 import './index.scss';
@@ -12,6 +13,8 @@ const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 
 root.render(
   <React.StrictMode>
-    <App/>
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Should be no real functionality change, just cleaning up a lot of the app logic that was reliant on passing props everywhere into proper hooks