### PR TITLE
Move scroll detection to hook, require user event

### DIFF
--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useCallback, useRef } from "react";
+import React, { useEffect, useCallback } from "react";
 
 import { classes } from "../../utils/classes";
 import useHiddenCursor from "./hooks/useHiddenCursor";
 import useSettings from "./hooks/useSettings";
 import useSleeping from "./hooks/useSleeping";
+import useScrolling from "./hooks/useScrolling";
 
 import Overlay from "./components/overlay/Overlay";
 import styles from "./App.module.scss";
@@ -20,7 +21,6 @@ export default function App() {
     on: addSleepListener,
     off: removeSleepListener,
   } = useSleeping();
-  const appRef = useRef<HTMLDivElement>(null);
 
   // When the user interacts, show the overlay
   const interacted = useCallback(() => wake(timeout), [wake]);
@@ -34,32 +34,16 @@ export default function App() {
     return () => removeSleepListener("wake", showCursor);
   }, [addSleepListener, removeSleepListener, showCursor]);
 
-  // When a user scrolls, treat it as an interaction (but handle Firefox being weird)
-  const scrollRef = useRef<[HTMLElement, number] | undefined>(undefined);
-  const scrolled = useCallback(
-    (e: Event) => {
-      const target = e.target as HTMLElement;
-
-      // If the scroll event is from the same element, and the scroll position is the same, ignore it
-      // This fixes a bug in Firefox where animating translate emits scroll events
-      if (scrollRef.current) {
-        const [node, scrollTop] = scrollRef.current;
-        if (node === target && scrollTop === target.scrollTop) return;
-      }
-
-      scrollRef.current = [target, target.scrollTop];
-      interacted();
-    },
-    [interacted]
-  );
-
-  // Bind a capturing event listener for scrolling (so we can see scrolling for children)
+  // When a user scrolls, treat it as an interaction
+  const {
+    ref: scrollRef,
+    on: addScrollListener,
+    off: removeScrollListener,
+  } = useScrolling();
   useEffect(() => {
-    if (!appRef.current) return;
-    const node = appRef.current;
-    node.addEventListener("scroll", scrolled, true);
-    return () => node.removeEventListener("scroll", scrolled, true);
-  }, [scrolled]);
+    addScrollListener(interacted);
+    return () => removeScrollListener(interacted);
+  }, [addScrollListener, removeScrollListener, interacted]);
 
   // Block sleeping hiding the overlay if dev toggle is on
   const settings = useSettings();
@@ -72,7 +56,7 @@ export default function App() {
 
   return (
     <div
-      ref={appRef}
+      ref={scrollRef}
       className={classes(styles.app, visibilityClass)}
       onMouseEnter={interacted}
       onMouseMove={interacted}

--- a/src/pages/overlay/hooks/useScrolling.ts
+++ b/src/pages/overlay/hooks/useScrolling.ts
@@ -55,15 +55,21 @@ const useScrolling = () => {
   );
 
   // Bind the event listeners to the scrollable element
+  const cleanup = useRef<() => void>();
   const ref = useCallback(
     (node: HTMLElement | null) => {
+      if (cleanup.current) {
+        cleanup.current();
+        cleanup.current = undefined;
+      }
+
       if (!node) return;
 
       node.addEventListener("scroll", onScroll, true);
       node.addEventListener("wheel", onWheel, true);
       node.addEventListener("touchmove", onTouchMove, true);
 
-      return () => {
+      cleanup.current = () => {
         node.removeEventListener("scroll", onScroll, true);
         node.removeEventListener("wheel", onWheel, true);
         node.removeEventListener("touchmove", onTouchMove, true);

--- a/src/pages/overlay/hooks/useScrolling.tsx
+++ b/src/pages/overlay/hooks/useScrolling.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Stop considering the user to be scrolling 100ms after the last scroll event
+const activityTimeout = 100;
+
+const useScrolling = () => {
+  // Allow subscriptions to scroll events
+  const [callbacks, setCallbacks] = useState<((e: Event) => void)[]>([]);
+  const on = useCallback((fn: (e: Event) => void) => {
+    setCallbacks((prev) => [...prev, fn]);
+  }, []);
+  const off = useCallback((fn: (e: Event) => void) => {
+    setCallbacks((prev) => prev.filter((f) => f !== fn));
+  }, []);
+
+  // Listen for the wheel event (user scrolling on desktop)
+  const onWheelTimer = useRef<NodeJS.Timeout | null>(null);
+  const onWheelActive = useRef(false);
+  const onWheel = useCallback(() => {
+    onWheelActive.current = true;
+
+    if (onWheelTimer.current) clearTimeout(onWheelTimer.current);
+    onWheelTimer.current = setTimeout(() => {
+      onWheelActive.current = false;
+    }, activityTimeout);
+  }, []);
+
+  // Listen for touch move events (user scrolling on mobile)
+  const onTouchMoveTimer = useRef<NodeJS.Timeout | null>(null);
+  const onTouchMoveActive = useRef(false);
+  const onTouchMove = useCallback(() => {
+    onTouchMoveActive.current = true;
+
+    if (onTouchMoveTimer.current) clearTimeout(onTouchMoveTimer.current);
+    onTouchMoveTimer.current = setTimeout(() => {
+      onTouchMoveActive.current = false;
+    }, activityTimeout);
+  }, []);
+
+  // Clean up the timers when the component unmounts
+  useEffect(() => {
+    return () => {
+      if (onWheelTimer.current) clearTimeout(onWheelTimer.current);
+      if (onTouchMoveTimer.current) clearTimeout(onTouchMoveTimer.current);
+    };
+  }, []);
+
+  // Call the subscribers if the user is actively scrolling
+  const onScroll = useCallback(
+    (e: Event) => {
+      if (!onWheelActive.current && !onTouchMoveActive.current) return;
+      callbacks.forEach((fn) => fn(e));
+    },
+    [callbacks]
+  );
+
+  // Bind the event listeners to the scrollable element
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) return;
+
+      node.addEventListener("scroll", onScroll, true);
+      node.addEventListener("wheel", onWheel, true);
+      node.addEventListener("touchmove", onTouchMove, true);
+
+      return () => {
+        node.removeEventListener("scroll", onScroll, true);
+        node.removeEventListener("wheel", onWheel, true);
+        node.removeEventListener("touchmove", onTouchMove, true);
+      };
+    },
+    [onScroll, onWheel, onTouchMove]
+  );
+
+  return { ref, on, off };
+};
+
+export default useScrolling;


### PR DESCRIPTION
Fixes #111 

When a chat command is run, and the user doesn't interact with the page, the card shown should auto-dismiss after 10s. When the user next interacts, the extension should not be showing any card.