### PR TITLE
Remove React imports for JSX

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,8 @@
     }
   },
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/src/pages/overlay/components/buttons/Buttons.tsx
+++ b/src/pages/overlay/components/buttons/Buttons.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import React from "react";
 
 import { classes } from "../../../../utils/classes";
 import Tooltip from "../../../../utils/global/tooltip/Tooltip";

--- a/src/pages/overlay/components/card/Card.tsx
+++ b/src/pages/overlay/components/card/Card.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { classes } from "../../../../utils/classes";
 
 import styles from "./card.module.scss";

--- a/src/pages/overlay/components/overlay/settings/Settings.tsx
+++ b/src/pages/overlay/components/overlay/settings/Settings.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { typeSafeObjectEntries } from "../../../../../utils/helpers";
 import useSettings from "../../../hooks/useSettings";
 

--- a/src/pages/overlay/components/overlay/welcome/Welcome.tsx
+++ b/src/pages/overlay/components/overlay/welcome/Welcome.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Card from "../../card/Card";
 import type { OverlayOptionProps } from "../Overlay";
 

--- a/src/pages/overlay/index.tsx
+++ b/src/pages/overlay/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 import { SettingsProvider } from "./hooks/useSettings";
@@ -10,16 +10,14 @@ import "./index.scss";
 
 bindTwitchAuth();
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement,
-);
+const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <SettingsProvider>
       <SleepingProvider>
         <App />
       </SleepingProvider>
     </SettingsProvider>
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/src/pages/panel/App.tsx
+++ b/src/pages/panel/App.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Nav from "./components/nav/Nav";
 import AmbassadorPanel from "./components/ambassadorPanel/AmbassadorPanel";
 

--- a/src/pages/panel/components/nav/Nav.tsx
+++ b/src/pages/panel/components/nav/Nav.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import AlveusLogo from "../../../../assets/alveus-logo.png";
 import styles from "./nav.module.scss";
 

--- a/src/pages/panel/index.tsx
+++ b/src/pages/panel/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 import { bindTwitchAuth } from "../../utils/twitch-api";
@@ -8,12 +8,10 @@ import "./index.scss";
 
 bindTwitchAuth();
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement,
-);
+const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/src/utils/global/ambassadorCard/AmbassadorCard.tsx
+++ b/src/utils/global/ambassadorCard/AmbassadorCard.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { calculateAge, formatDate, isBirthday } from "../../dateManager";
 import {
   getAmbassadorImages,


### PR DESCRIPTION
We're using the react-jsx transform, which doesn't require React be imported into every JSX usage (https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)