### PR TITLE
Change to tooltip to fit mobile panel

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -42,8 +42,16 @@ const Tooltip = (props: TooltipProps) => {
         setIsOverflowing(true);
         setPosition({
           top: rect.top - rect.height / 2 - tooltipRect.height,
-          left: rect.right - tooltipRect.width / 2 - 5,
+          left: window.innerWidth / 2 - tooltipRect.width / 2,
         });
+        // Calculate margin so triangle will be pointing to info icon
+        const calcTriangleMargin = `${
+          window.innerWidth / 2 - rect.right + 5
+        }px`;
+        document.documentElement.style.setProperty(
+          "--tooltip-margin-right",
+          calcTriangleMargin,
+        );
       } else {
         // Position tooltip to the left
         setIsOverflowing(false);

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -28,7 +28,7 @@ const Tooltip = (props: TooltipProps) => {
   const [show, setShow] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const [above, setAbove] = useState(false);
-  const [triangleMargin, setTriangleMargin] = useState("0px");
+  const [triangleMargin, setTriangleMargin] = useState<string>();
 
   // On hover, compute position of tooltip and show it
   const handleEnter = useCallback(
@@ -47,7 +47,7 @@ const Tooltip = (props: TooltipProps) => {
           left: window.innerWidth / 2 - tooltipRect.width / 2,
         });
         // Calculate margin so triangle will be pointing to info icon
-        setTriangleMargin(`${window.innerWidth / 2 - rect.right + 5}px`);
+        setTriangleMargin(`0 ${window.innerWidth / 2 - rect.right + 5}px 0 0`);
       } else {
         // Position tooltip to the left
         setAbove(false);
@@ -55,6 +55,8 @@ const Tooltip = (props: TooltipProps) => {
           top: rect.top + rect.height / 2 - tooltipRect.height / 2,
           left: rect.right + 10,
         });
+        // Have the triangle be in the center of the tooltip
+        setTriangleMargin("-5px 0 0");
       }
       setShow(true);
     },
@@ -102,7 +104,7 @@ const Tooltip = (props: TooltipProps) => {
       >
         <div
           className={above ? styles.triangleBottom : styles.triangleLeft}
-          style={{ marginRight: above ? triangleMargin : "0" }}
+          style={{ margin: triangleMargin }}
         />
         {text}
       </div>

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -41,8 +41,8 @@ const Tooltip = (props: TooltipProps) => {
         // If the tooltip box is past the right edge of the page, position it to the top
         setIsOverflowing(true);
         setPosition({
-          top: rect.top - tooltipRect.height - 7,
-          left: rect.left - 4,
+          top: rect.top - rect.height / 2 - tooltipRect.height,
+          left: rect.right - tooltipRect.width / 2 - 5,
         });
       } else {
         // Position tooltip to the left

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ interface TooltipProps {
   fontSize?: string;
   maxWidth?: string;
 }
+
 const Tooltip = (props: TooltipProps) => {
   const { text, children, fontSize, maxWidth } = props;
 
@@ -26,7 +27,8 @@ const Tooltip = (props: TooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [show, setShow] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
-  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [above, setAbove] = useState(false);
+  const [triangleMargin, setTriangleMargin] = useState("0px");
 
   // On hover, compute position of tooltip and show it
   const handleEnter = useCallback(
@@ -39,22 +41,16 @@ const Tooltip = (props: TooltipProps) => {
 
       if (rect.right + tooltipRect.width > window.innerWidth) {
         // If the tooltip box is past the right edge of the page, position it to the top
-        setIsOverflowing(true);
+        setAbove(true);
         setPosition({
           top: rect.top - rect.height / 2 - tooltipRect.height,
           left: window.innerWidth / 2 - tooltipRect.width / 2,
         });
         // Calculate margin so triangle will be pointing to info icon
-        const calcTriangleMargin = `${
-          window.innerWidth / 2 - rect.right + 5
-        }px`;
-        document.documentElement.style.setProperty(
-          "--tooltip-margin-right",
-          calcTriangleMargin,
-        );
+        setTriangleMargin(`${window.innerWidth / 2 - rect.right + 5}px`);
       } else {
         // Position tooltip to the left
-        setIsOverflowing(false);
+        setAbove(false);
         setPosition({
           top: rect.top + rect.height / 2 - tooltipRect.height / 2,
           left: rect.right + 10,
@@ -105,9 +101,8 @@ const Tooltip = (props: TooltipProps) => {
         role="tooltip"
       >
         <div
-          className={
-            isOverflowing ? styles.triangle_bottom : styles.triangle_left
-          }
+          className={above ? styles.triangleBottom : styles.triangleLeft}
+          style={{ marginRight: above ? triangleMargin : "0" }}
         />
         {text}
       </div>

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -19,7 +19,6 @@ interface TooltipProps {
   fontSize?: string;
   maxWidth?: string;
 }
-
 const Tooltip = (props: TooltipProps) => {
   const { text, children, fontSize, maxWidth } = props;
 
@@ -27,6 +26,7 @@ const Tooltip = (props: TooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [show, setShow] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
+  const [isOverflowing, setIsOverflowing] = useState(false);
 
   // On hover, compute position of tooltip and show it
   const handleEnter = useCallback(
@@ -37,10 +37,21 @@ const Tooltip = (props: TooltipProps) => {
       const rect = target.getBoundingClientRect();
       const tooltipRect = tooltipRef.current.getBoundingClientRect();
 
-      setPosition({
-        top: rect.top + rect.height / 2 - tooltipRect.height / 2,
-        left: rect.right + 10,
-      });
+      if (rect.right + tooltipRect.width > window.innerWidth) {
+        // If the tooltip box is past the right edge of the page, position it to the top
+        setIsOverflowing(true);
+        setPosition({
+          top: rect.top - tooltipRect.height - 7,
+          left: rect.left - 4,
+        });
+      } else {
+        // Position tooltip to the left
+        setIsOverflowing(false);
+        setPosition({
+          top: rect.top + rect.height / 2 - tooltipRect.height / 2,
+          left: rect.right + 10,
+        });
+      }
       setShow(true);
     },
     [],
@@ -85,7 +96,11 @@ const Tooltip = (props: TooltipProps) => {
         id={id}
         role="tooltip"
       >
-        <span className={styles.triangle} />
+        <div
+          className={
+            isOverflowing ? styles.triangle_bottom : styles.triangle_left
+          }
+        />
         {text}
       </div>
     </>

--- a/src/components/tooltip/tooltip.module.scss
+++ b/src/components/tooltip/tooltip.module.scss
@@ -12,7 +12,16 @@
   width: max-content;
   z-index: 1;
 
-  .triangle {
+  .triangle_bottom {
+    border-color: $tooltip-background-color transparent transparent transparent;
+    border-style: solid;
+    border-width: 5px;
+    margin-top: -5px;
+    position: absolute;
+    top: 105%;
+    right: 43.6%;
+  }
+  .triangle_left {
     border-color: transparent $tooltip-background-color transparent transparent;
     border-style: solid;
     border-width: 5px;

--- a/src/components/tooltip/tooltip.module.scss
+++ b/src/components/tooltip/tooltip.module.scss
@@ -17,6 +17,7 @@
     border-style: solid;
     border-width: 5px;
     position: absolute;
+    margin-right: var(--tooltip-margin-right);
     top: 100%;
     right: 50%;
   }

--- a/src/components/tooltip/tooltip.module.scss
+++ b/src/components/tooltip/tooltip.module.scss
@@ -25,7 +25,6 @@
     border-color: transparent $tooltip-background-color transparent transparent;
     border-style: solid;
     border-width: 5px;
-    margin-top: -5px;
     position: absolute;
     right: 100%;
     top: 50%;

--- a/src/components/tooltip/tooltip.module.scss
+++ b/src/components/tooltip/tooltip.module.scss
@@ -12,16 +12,16 @@
   width: max-content;
   z-index: 1;
 
-  .triangle_bottom {
+  .triangleBottom {
     border-color: $tooltip-background-color transparent transparent transparent;
     border-style: solid;
     border-width: 5px;
     position: absolute;
-    margin-right: var(--tooltip-margin-right);
     top: 100%;
     right: 50%;
   }
-  .triangle_left {
+
+  .triangleLeft {
     border-color: transparent $tooltip-background-color transparent transparent;
     border-style: solid;
     border-width: 5px;

--- a/src/components/tooltip/tooltip.module.scss
+++ b/src/components/tooltip/tooltip.module.scss
@@ -16,10 +16,9 @@
     border-color: $tooltip-background-color transparent transparent transparent;
     border-style: solid;
     border-width: 5px;
-    margin-top: -5px;
     position: absolute;
-    top: 105%;
-    right: 43.6%;
+    top: 100%;
+    right: 50%;
   }
   .triangle_left {
     border-color: transparent $tooltip-background-color transparent transparent;


### PR DESCRIPTION
Resolves #115 

Wrote a condition that checks whether tooltip fits to the right, if not tooltip is shown on the top. Also changed the position of the triangle to the bottom of the tooltip for that case.

![overflowing](https://github.com/alveusgg/extension/assets/147619232/ec1df7ed-1d8f-4024-af32-71134f0295f8)
![notoverflowing](https://github.com/alveusgg/extension/assets/147619232/53454100-95ca-4a42-bfac-40d7ec7288e2)
