### PR TITLE
Add extra channels to connect to when not in default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS=abdullahmorrison,mattipv4,pjeweb,alveusgg,spacevoyage
 REACT_APP_DEFAULT_CHANNEL_NAMES=maya,alveussanctuary
+REACT_APP_EXTRA_CHANNEL_NAMES=alveusgg


### PR DESCRIPTION
Resolves #152

Make sure your `.env` is updated to test, and this will need to be tested with a localhost extension on Twitch itself, as it will only connect to the extra channels when it knows what Twitch channel it is on.