### PR TITLE
Make ambassador cards shiny

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@alveusgg/data": "github:alveusgg/data#0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-parallax-tilt": "^1.7.222",
         "tmi.js": "^1.8.5"
       },
       "devDependencies": {
@@ -8755,6 +8756,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-parallax-tilt": {
+      "version": "1.7.222",
+      "resolved": "https://registry.npmjs.org/react-parallax-tilt/-/react-parallax-tilt-1.7.222.tgz",
+      "integrity": "sha512-lBB9N2QtGFkvIxsFQXM4O3V7p0oa2z9uO63TXzQTyS7MSRcycK+54iyAn/brOwkB+pouOa5yYNgUWBHzlDsDCg==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -16972,6 +16982,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "react-parallax-tilt": {
+      "version": "1.7.222",
+      "resolved": "https://registry.npmjs.org/react-parallax-tilt/-/react-parallax-tilt-1.7.222.tgz",
+      "integrity": "sha512-lBB9N2QtGFkvIxsFQXM4O3V7p0oa2z9uO63TXzQTyS7MSRcycK+54iyAn/brOwkB+pouOa5yYNgUWBHzlDsDCg==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@alveusgg/data": "github:alveusgg/data#0.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-parallax-tilt": "^1.7.222",
     "tmi.js": "^1.8.5"
   },
   "devDependencies": {

--- a/src/components/ambassadorCard/AmbassadorCard.tsx
+++ b/src/components/ambassadorCard/AmbassadorCard.tsx
@@ -53,6 +53,7 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
       glarePosition="bottom"
       scale={1.0}
       perspective={2500}
+      tiltReverse
       className={classes(
         styles.ambassadorCard,
         className,

--- a/src/components/ambassadorCard/AmbassadorCard.tsx
+++ b/src/components/ambassadorCard/AmbassadorCard.tsx
@@ -32,20 +32,25 @@ export interface AmbassadorCardProps {
   ambassador: AmbassadorType;
   onClose?: () => void;
   className?: string;
+  disableCardEffects?: boolean;
 }
 
 export default function AmbassadorCard(props: AmbassadorCardProps) {
-  const { ambassadorKey, ambassador, onClose, className } = props;
+  const { ambassadorKey, ambassador, onClose, className, disableCardEffects } =
+    props;
   const images = getAmbassadorImages(ambassadorKey);
   const mod =
     window?.Twitch?.ext?.viewer?.role === "broadcaster" ||
     window?.Twitch?.ext?.viewer?.role === "moderator";
+  const glareOpacity = disableCardEffects ? 0.0 : 0.5;
 
   return (
     <Tilt
-      glareEnable={true}
-      glareMaxOpacity={0.5}
+      tiltEnable={!disableCardEffects}
+      glareEnable={!disableCardEffects}
+      glareMaxOpacity={glareOpacity}
       glareBorderRadius="1rem"
+      glarePosition="bottom"
       scale={1.0}
       perspective={5000}
       className={classes(styles.ambassadorCard, className)}

--- a/src/components/ambassadorCard/AmbassadorCard.tsx
+++ b/src/components/ambassadorCard/AmbassadorCard.tsx
@@ -52,134 +52,130 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
       glareBorderRadius="1rem"
       glarePosition="bottom"
       scale={1.0}
-      perspective={5000}
-      className={classes(styles.ambassadorCard, className)}
+      perspective={2500}
+      className={classes(
+        styles.ambassadorCard,
+        className,
+        ambassador.birth && isBirthday(ambassador.birth) && styles.birthday,
+      )}
     >
-      <div
-        className={classes(
-          ambassador.birth && isBirthday(ambassador.birth) && styles.birthday,
+      <div className={styles.hero}>
+        <img
+          className={styles.img}
+          src={images[0].src}
+          alt={images[0].alt}
+          style={{ objectPosition: offsetPosition(images[0].position) }}
+        />
+
+        <div className={styles.overlay}>
+          {props.onClose && (
+            <button
+              className={styles.close}
+              onClick={onClose}
+              type="button"
+              aria-label="Close"
+            >
+              &times;
+            </button>
+          )}
+
+          <h2 className={styles.name} title={ambassador.name}>
+            {ambassador.name}
+          </h2>
+        </div>
+      </div>
+
+      <div className={styles.scrollable}>
+        {mod && (
+          <div className={styles.mod}>
+            <img src={moderatorBadge} alt="Moderator badge" />
+            <p>
+              Show this card to everyone by using{" "}
+              <code>!{normalizeAmbassadorName(ambassador.name, true)}</code> in
+              chat.
+            </p>
+          </div>
         )}
-      >
-        <div className={styles.hero}>
-          <img
-            className={styles.img}
-            src={images[0].src}
-            alt={images[0].alt}
-            style={{ objectPosition: offsetPosition(images[0].position) }}
-          />
 
-          <div className={styles.overlay}>
-            {props.onClose && (
-              <button
-                className={styles.close}
-                onClick={onClose}
-                type="button"
-                aria-label="Close"
-              >
-                &times;
-              </button>
-            )}
+        <div>
+          <h3>Species</h3>
+          <p>{ambassador.species}</p>
+          <p>
+            <i>
+              {ambassador.scientific} ({getClassification(ambassador.class)})
+            </i>
+          </p>
+        </div>
 
-            <h2 className={styles.name} title={ambassador.name}>
-              {ambassador.name}
-            </h2>
+        <div className={styles.compact}>
+          <div>
+            <h3>Sex</h3>
+            <p>{ambassador.sex || "Unknown"}</p>
+          </div>
+          <div>
+            <h3>Age</h3>
+            <p>
+              {ambassador.birth ? calculateAge(ambassador.birth) : "Unknown"}
+            </p>
+          </div>
+          <div>
+            <h3>Birthday</h3>
+            <p>{ambassador.birth ? formatDate(ambassador.birth) : "Unknown"}</p>
           </div>
         </div>
 
-        <div className={styles.scrollable}>
-          {mod && (
-            <div className={styles.mod}>
-              <img src={moderatorBadge} alt="Moderator badge" />
-              <p>
-                Show this card to everyone by using{" "}
-                <code>!{normalizeAmbassadorName(ambassador.name, true)}</code>{" "}
-                in chat.
-              </p>
+        <div>
+          <h3>Story</h3>
+          <p>{ambassador.story}</p>
+        </div>
+
+        <div>
+          <h3>Conservation Mission</h3>
+          <p>{ambassador.mission}</p>
+        </div>
+
+        <div>
+          <Tooltip
+            text="An objective assessment system for classifying the status of plants, animals, and other organisms threatened with extinction."
+            maxWidth="18rem"
+            fontSize="0.9rem"
+          >
+            <div className={styles.info}>
+              <h3>Conservation Status</h3>
+              <IconInfo size={20} />
             </div>
-          )}
+          </Tooltip>
+          <p>IUCN: {getIUCNStatus(ambassador.iucn.status)}</p>
+        </div>
 
-          <div>
-            <h3>Species</h3>
-            <p>{ambassador.species}</p>
-            <p>
-              <i>
-                {ambassador.scientific} ({getClassification(ambassador.class)})
-              </i>
-            </p>
-          </div>
+        <div>
+          <h3>Native To</h3>
+          <p>{ambassador.native.text}</p>
+        </div>
 
-          <div className={styles.compact}>
-            <div>
-              <h3>Sex</h3>
-              <p>{ambassador.sex || "Unknown"}</p>
-            </div>
-            <div>
-              <h3>Age</h3>
-              <p>
-                {ambassador.birth ? calculateAge(ambassador.birth) : "Unknown"}
-              </p>
-            </div>
-            <div>
-              <h3>Birthday</h3>
-              <p>
-                {ambassador.birth ? formatDate(ambassador.birth) : "Unknown"}
-              </p>
-            </div>
-          </div>
+        <div>
+          <h3>Arrived at Alveus</h3>
+          <p>
+            {ambassador.arrival
+              ? formatDate(ambassador.arrival, false)
+              : "Unknown"}
+          </p>
+        </div>
 
-          <div>
-            <h3>Story</h3>
-            <p>{ambassador.story}</p>
-          </div>
-
-          <div>
-            <h3>Conservation Mission</h3>
-            <p>{ambassador.mission}</p>
-          </div>
-
-          <div>
-            <Tooltip
-              text="An objective assessment system for classifying the status of plants, animals, and other organisms threatened with extinction."
-              maxWidth="18rem"
-              fontSize="0.9rem"
+        <div className={styles.site}>
+          <p>
+            Learn more about {ambassador.name} on the{" "}
+            <a
+              href={`https://www.alveussanctuary.org/ambassadors/${camelToKebab(
+                ambassadorKey,
+              )}`}
+              rel="noreferrer"
+              target="_blank"
             >
-              <div className={styles.info}>
-                <h3>Conservation Status</h3>
-                <IconInfo size={20} />
-              </div>
-            </Tooltip>
-            <p>IUCN: {getIUCNStatus(ambassador.iucn.status)}</p>
-          </div>
-
-          <div>
-            <h3>Native To</h3>
-            <p>{ambassador.native.text}</p>
-          </div>
-
-          <div>
-            <h3>Arrived at Alveus</h3>
-            <p>
-              {ambassador.arrival
-                ? formatDate(ambassador.arrival, false)
-                : "Unknown"}
-            </p>
-          </div>
-
-          <div className={styles.site}>
-            <p>
-              Learn more about {ambassador.name} on the{" "}
-              <a
-                href={`https://www.alveussanctuary.org/ambassadors/${camelToKebab(
-                  ambassadorKey,
-                )}`}
-                rel="noreferrer"
-                target="_blank"
-              >
-                Alveus Sanctuary website
-              </a>
-              .
-            </p>
-          </div>
+              Alveus Sanctuary website
+            </a>
+            .
+          </p>
         </div>
       </div>
     </Tilt>

--- a/src/components/ambassadorCard/AmbassadorCard.tsx
+++ b/src/components/ambassadorCard/AmbassadorCard.tsx
@@ -40,7 +40,7 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
   const mod =
     window?.Twitch?.ext?.viewer?.role === "broadcaster" ||
     window?.Twitch?.ext?.viewer?.role === "moderator";
-  const glareOpacity = disableCardEffects ? 0.0 : 0.5;
+  const glareOpacity = disableCardEffects ? 0.0 : 0.3;
 
   return (
     <Tilt
@@ -52,6 +52,7 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
       scale={1.0}
       perspective={2500}
       tiltReverse
+      transitionSpeed={3000}
       className={classes(
         styles.ambassadorCard,
         className,

--- a/src/components/ambassadorCard/AmbassadorCard.tsx
+++ b/src/components/ambassadorCard/AmbassadorCard.tsx
@@ -20,6 +20,8 @@ import moderatorBadge from "../../assets/mod.svg";
 
 import styles from "./ambassadorCard.module.scss";
 
+import Tilt from "react-parallax-tilt";
+
 const offsetPosition = (position: AmbassadorImage["position"]) => {
   const [x, y] = (position || "50% 50%").split(" ");
   return `${x} min(calc(${y} + 1.5rem), 0%)`;
@@ -40,132 +42,141 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
     window?.Twitch?.ext?.viewer?.role === "moderator";
 
   return (
-    <div
-      className={classes(
-        styles.ambassadorCard,
-        className,
-        ambassador.birth && isBirthday(ambassador.birth) && styles.birthday,
-      )}
+    <Tilt
+      glareEnable={true}
+      glareMaxOpacity={0.5}
+      glareBorderRadius="1rem"
+      scale={1.0}
+      perspective={5000}
+      className={classes(styles.ambassadorCard, className)}
     >
-      <div className={styles.hero}>
-        <img
-          className={styles.img}
-          src={images[0].src}
-          alt={images[0].alt}
-          style={{ objectPosition: offsetPosition(images[0].position) }}
-        />
+      <div
+        className={classes(
+          ambassador.birth && isBirthday(ambassador.birth) && styles.birthday,
+        )}
+      >
+        <div className={styles.hero}>
+          <img
+            className={styles.img}
+            src={images[0].src}
+            alt={images[0].alt}
+            style={{ objectPosition: offsetPosition(images[0].position) }}
+          />
 
-        <div className={styles.overlay}>
-          {props.onClose && (
-            <button
-              className={styles.close}
-              onClick={onClose}
-              type="button"
-              aria-label="Close"
-            >
-              &times;
-            </button>
+          <div className={styles.overlay}>
+            {props.onClose && (
+              <button
+                className={styles.close}
+                onClick={onClose}
+                type="button"
+                aria-label="Close"
+              >
+                &times;
+              </button>
+            )}
+
+            <h2 className={styles.name} title={ambassador.name}>
+              {ambassador.name}
+            </h2>
+          </div>
+        </div>
+
+        <div className={styles.scrollable}>
+          {mod && (
+            <div className={styles.mod}>
+              <img src={moderatorBadge} alt="Moderator badge" />
+              <p>
+                Show this card to everyone by using{" "}
+                <code>!{normalizeAmbassadorName(ambassador.name, true)}</code>{" "}
+                in chat.
+              </p>
+            </div>
           )}
 
-          <h2 className={styles.name} title={ambassador.name}>
-            {ambassador.name}
-          </h2>
-        </div>
-      </div>
-
-      <div className={styles.scrollable}>
-        {mod && (
-          <div className={styles.mod}>
-            <img src={moderatorBadge} alt="Moderator badge" />
+          <div>
+            <h3>Species</h3>
+            <p>{ambassador.species}</p>
             <p>
-              Show this card to everyone by using{" "}
-              <code>!{normalizeAmbassadorName(ambassador.name, true)}</code> in
-              chat.
+              <i>
+                {ambassador.scientific} ({getClassification(ambassador.class)})
+              </i>
             </p>
           </div>
-        )}
 
-        <div>
-          <h3>Species</h3>
-          <p>{ambassador.species}</p>
-          <p>
-            <i>
-              {ambassador.scientific} ({getClassification(ambassador.class)})
-            </i>
-          </p>
-        </div>
-
-        <div className={styles.compact}>
-          <div>
-            <h3>Sex</h3>
-            <p>{ambassador.sex || "Unknown"}</p>
-          </div>
-          <div>
-            <h3>Age</h3>
-            <p>
-              {ambassador.birth ? calculateAge(ambassador.birth) : "Unknown"}
-            </p>
-          </div>
-          <div>
-            <h3>Birthday</h3>
-            <p>{ambassador.birth ? formatDate(ambassador.birth) : "Unknown"}</p>
-          </div>
-        </div>
-
-        <div>
-          <h3>Story</h3>
-          <p>{ambassador.story}</p>
-        </div>
-
-        <div>
-          <h3>Conservation Mission</h3>
-          <p>{ambassador.mission}</p>
-        </div>
-
-        <div>
-          <Tooltip
-            text="An objective assessment system for classifying the status of plants, animals, and other organisms threatened with extinction."
-            maxWidth="18rem"
-            fontSize="0.9rem"
-          >
-            <div className={styles.info}>
-              <h3>Conservation Status</h3>
-              <IconInfo size={20} />
+          <div className={styles.compact}>
+            <div>
+              <h3>Sex</h3>
+              <p>{ambassador.sex || "Unknown"}</p>
             </div>
-          </Tooltip>
-          <p>IUCN: {getIUCNStatus(ambassador.iucn.status)}</p>
-        </div>
+            <div>
+              <h3>Age</h3>
+              <p>
+                {ambassador.birth ? calculateAge(ambassador.birth) : "Unknown"}
+              </p>
+            </div>
+            <div>
+              <h3>Birthday</h3>
+              <p>
+                {ambassador.birth ? formatDate(ambassador.birth) : "Unknown"}
+              </p>
+            </div>
+          </div>
 
-        <div>
-          <h3>Native To</h3>
-          <p>{ambassador.native.text}</p>
-        </div>
+          <div>
+            <h3>Story</h3>
+            <p>{ambassador.story}</p>
+          </div>
 
-        <div>
-          <h3>Arrived at Alveus</h3>
-          <p>
-            {ambassador.arrival
-              ? formatDate(ambassador.arrival, false)
-              : "Unknown"}
-          </p>
-        </div>
+          <div>
+            <h3>Conservation Mission</h3>
+            <p>{ambassador.mission}</p>
+          </div>
 
-        <div className={styles.site}>
-          <p>
-            Learn more about {ambassador.name} on the{" "}
-            <a
-              href={`https://www.alveussanctuary.org/ambassadors/${camelToKebab(
-                ambassadorKey,
-              )}`}
-              rel="noreferrer"
-              target="_blank"
+          <div>
+            <Tooltip
+              text="An objective assessment system for classifying the status of plants, animals, and other organisms threatened with extinction."
+              maxWidth="18rem"
+              fontSize="0.9rem"
             >
-              Alveus Sanctuary website
-            </a>
-            .
-          </p>
+              <div className={styles.info}>
+                <h3>Conservation Status</h3>
+                <IconInfo size={20} />
+              </div>
+            </Tooltip>
+            <p>IUCN: {getIUCNStatus(ambassador.iucn.status)}</p>
+          </div>
+
+          <div>
+            <h3>Native To</h3>
+            <p>{ambassador.native.text}</p>
+          </div>
+
+          <div>
+            <h3>Arrived at Alveus</h3>
+            <p>
+              {ambassador.arrival
+                ? formatDate(ambassador.arrival, false)
+                : "Unknown"}
+            </p>
+          </div>
+
+          <div className={styles.site}>
+            <p>
+              Learn more about {ambassador.name} on the{" "}
+              <a
+                href={`https://www.alveussanctuary.org/ambassadors/${camelToKebab(
+                  ambassadorKey,
+                )}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Alveus Sanctuary website
+              </a>
+              .
+            </p>
+          </div>
         </div>
       </div>
-    </div>
+    </Tilt>
   );
 }

--- a/src/components/ambassadorCard/ambassadorCard.module.scss
+++ b/src/components/ambassadorCard/ambassadorCard.module.scss
@@ -15,7 +15,7 @@
   box-shadow: $shadow;
 
   border-radius: 1rem;
-  overflow: hidden;
+  overflow: visible;
 
   color: $primary-text;
   font-size: 0.7rem;
@@ -41,6 +41,7 @@
       width: 100%;
       object-fit: cover;
       aspect-ratio: 2.2;
+      border-radius: 1rem 1rem 0rem 0rem;
 
       @media (min-width: 480px) {
         aspect-ratio: 1.8;
@@ -64,6 +65,7 @@
       backdrop-filter: blur(0.25rem);
       transition: $transition;
       transition-property: opacity, backdrop-filter;
+      border-radius: 1rem 1rem 0rem 0rem;
 
       .name {
         font-size: 1.3rem;

--- a/src/pages/overlay/components/overlay/ambassadors/Ambassadors.tsx
+++ b/src/pages/overlay/components/overlay/ambassadors/Ambassadors.tsx
@@ -14,6 +14,8 @@ import type { OverlayOptionProps } from "../Overlay";
 import styles from "./ambassadors.module.scss";
 import IconChevron from "../../../../../components/icons/IconChevron";
 
+import useSettings from "../../../hooks/useSettings";
+
 export default function Ambassadors(props: OverlayOptionProps) {
   const {
     context: { activeAmbassador, setActiveAmbassador },
@@ -84,6 +86,8 @@ export default function Ambassadors(props: OverlayOptionProps) {
     handleArrowVisibility();
   }, [handleArrowVisibility]);
 
+  const settings = useSettings();
+
   return (
     <div className={classes(styles.ambassadorList, className)}>
       <div className={styles.scroll}>
@@ -136,6 +140,7 @@ export default function Ambassadors(props: OverlayOptionProps) {
           ambassador={ambassadors[activeAmbassador.key]}
           onClose={() => setActiveAmbassador({})}
           className={styles.ambassadorCard}
+          disableCardEffects={settings.disableCardEffects.value}
         />
       )}
     </div>

--- a/src/pages/overlay/components/overlay/ambassadors/ambassadors.module.scss
+++ b/src/pages/overlay/components/overlay/ambassadors/ambassadors.module.scss
@@ -120,7 +120,6 @@ $fade-distance: 3rem;
   .ambassadorCard {
     align-self: center;
     z-index: 0; // stay below ambassadors list
-    transform-origin: center left;
     animation: slideIn 0.5s ease-in-out;
 
     @media (prefers-reduced-motion) {

--- a/src/pages/overlay/hooks/useSettings.tsx
+++ b/src/pages/overlay/hooks/useSettings.tsx
@@ -35,6 +35,12 @@ const settings = {
     },
     configurable: false,
   },
+  disableCardEffects: {
+    title: "Disable Ambassador Card Effects",
+    type: "boolean",
+    process: (value: any) => !!value,
+    configurable: true,
+  },
 };
 
 type SettingsKey = keyof typeof settings;


### PR DESCRIPTION
Resolves [#67](https://github.com/alveusgg/extension/issues/67)

- Used [react-parallax-tilt](https://www.npmjs.com/package/react-parallax-tilt) to create tilt and shine effects on ambassador cards.
- Added respective user setting to disable card effects.