### PR TITLE
Ensure consistent string case for channel name checks

### DIFF
--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -13,8 +13,8 @@ export default () => {
 
     fetchCurrentChannelInfo(auth)
       .then((newChannelInfo) => {
-        if (typeof newChannelInfo?.broadcaster_name === "string") {
-          setChannelName(newChannelInfo.broadcaster_name);
+        if (typeof newChannelInfo?.broadcaster_login === "string") {
+          setChannelName(newChannelInfo.broadcaster_login.toLowerCase());
         }
       })
       .catch((e) => {

--- a/src/hooks/useChatCommand.ts
+++ b/src/hooks/useChatCommand.ts
@@ -6,14 +6,19 @@ import { typeSafeObjectEntries } from "../utils/helpers";
 
 import useChannel from "./useChannel";
 
-const testChannelNames =
-  process.env.REACT_APP_TEST_CHANNEL_NAMES?.split(",") ?? [];
-const defaultChannelNames =
-  process.env.REACT_APP_DEFAULT_CHANNEL_NAMES?.split(",") ?? [];
-const extraChannelNames =
-  process.env.REACT_APP_EXTRA_CHANNEL_NAMES?.split(",") ?? [];
-const privilegedUsers =
-  process.env.REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS?.split(",") ?? [];
+const parseCsvEnv = (env: string | undefined): string[] =>
+  env?.split(",").map((str) => str.toLowerCase()) ?? [];
+
+const testChannelNames = parseCsvEnv(process.env.REACT_APP_TEST_CHANNEL_NAMES);
+const defaultChannelNames = parseCsvEnv(
+  process.env.REACT_APP_DEFAULT_CHANNEL_NAMES,
+);
+const extraChannelNames = parseCsvEnv(
+  process.env.REACT_APP_EXTRA_CHANNEL_NAMES,
+);
+const privilegedUsers = parseCsvEnv(
+  process.env.REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS,
+);
 
 const getAmbassadorCommandsMap = (): Map<string, AmbassadorKey> => {
   const commandMap = new Map<string, AmbassadorKey>();
@@ -67,7 +72,7 @@ export default function useChatCommand(callback: (command: string) => void) {
       if (
         !tags.mod &&
         !tags.badges?.broadcaster &&
-        !privilegedUsers.includes(tags.username ?? "")
+        !privilegedUsers.includes(tags.username?.toLowerCase() ?? "")
       )
         return;
       // Ignore echoed messages (messages sent by the bot) and messages that don't start with '!'


### PR DESCRIPTION
We have `alveussanctuary` in the default set of channel names, so when the extension is active in this channel it should not be watching the extra channel names including `alveusgg`. However, as seen in recent collaborations, commands run in `alveusgg` where controlling the extension in `alveussanctuary`.

After some investigation, the issue stems from the `broadcaster_name` for `alveussanctuary` actually being `AlveusSanctuary`. I've solved this in a few different places for some redundancy -- switching to `broadcaster_login` gives us back `alveussanctuary` instead, and then I've ensured we're normalizing all the values used for these name checks to always be lowercase.