### PR TITLE
Don't continually recreate chat connection

### DIFF
--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -128,7 +128,7 @@ export default function Overlay() {
           wake(commandTimeout);
         }
       },
-      [settings.disableChatPopup, wake],
+      [settings.disableChatPopup.value, wake],
     ),
   );
 


### PR DESCRIPTION
`settings.disableChatPopup` was a dependency of the callback being passed into the chat connection, which is a changing object (while stable in a `useMemo`, settings change when a command is run, which recreates the object). This caused the chat to reconnect every time the React component updated, such as when a chat command was run.

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/49d8c0d6-fd90-409f-8aff-1ac65bafce5c) | ![image](https://github.com/user-attachments/assets/0850e9f0-ec1c-464e-8088-03d3684690aa) |
