### PR TITLE
Add dependabot config for GitHub Actions + NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: "00:00"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: "00:00"
+
+    # Ensure the new version is stored in `package.json`
+    versioning-strategy: increase
+
+    # Update `dependencies` and `devDependencies` separately
+    # Create grouped PRs for minor/patch updates
+    # Major version updates will get individual PRs
+    groups:
+      production:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      development:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+
+    # Manually update major versions of `@types/node` with the version specified within .nvmrc
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Same config that we've settled on over in https://github.com/alveusgg/alveusgg, sans the pnpmfile bit as we don't use pnpm here and hopefully npm shouldn't have the same GitHub SSH deps issue.