### PR TITLE
Allow Dependabot to access @alveusgg/data from GitHub Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GH_PKG_REGISTRY_TOKEN}}
+
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -13,6 +20,9 @@ updates:
       interval: weekly
       day: wednesday
       time: "00:00"
+
+    # Allow usage of any registry including npm-github w/ auth as above
+    registries: "*"
 
     # Ensure the new version is stored in `package.json`
     versioning-strategy: increase

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
+# Explicitly set the default registry to npmjs.org
+# Stops Dependabot using its GitHub Packages registry definition for everything
+registry=https://registry.npmjs.org
+
+# Use the GitHub Packages registry for @alveusgg packages
 @alveusgg:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Same changes as in https://github.com/alveusgg/alveusgg/pull/989, also tested in a fork.