### PR TITLE
Enable erasableSyntaxOnly + verbatimModuleSyntax + noUncheckedIndexedAccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ https://user-images.githubusercontent.com/49528805/229295376-6490d0a5-5f01-456b-
 6. Copy the `.env.development.sample` file to `.env.development`. You may add a channel and user to test chat commands here (e.g. `REACT_APP_CHAT_COMMANDS_TEST_CHANNEL=testuser` and `REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS=testuser`)
 7. Start the development server with `pnpm dev`
 
+If you're using VSCode, add `"typescript.tsdk": "node_modules/typescript/lib"` to `.vscode/settings.json` to ensure you're using the correct TypeScript version.
+
 There are two ways to run the extension. You can either add it to a channel on Twitch, or access the web pages for the panel/overlay directly.
 
 ### Running via Twitch

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alveusgg/extension.git"
@@ -18,8 +19,8 @@
   "scripts": {
     "prepare": "husky",
     "lint-staged": "lint-staged --relative",
-    "dev": "cross-env NODE_ENV=development webpack serve --config src/webpack.config.ts",
-    "build": "webpack --config src/webpack.config.ts",
+    "dev": "cross-env NODE_ENV=development NODE_OPTIONS=\"--loader ts-node/esm\" webpack serve --config src/webpack.config.ts",
+    "build": "cross-env NODE_OPTIONS=\"--loader ts-node/esm\" webpack --config src/webpack.config.ts",
     "lint:eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint:prettier": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,json,html}\"",
     "lint": "run-p lint:*",

--- a/src/hooks/useAmbassadors.tsx
+++ b/src/hooks/useAmbassadors.tsx
@@ -1,10 +1,10 @@
 import {
-  ContextType,
   createContext,
   useContext,
   useEffect,
   useMemo,
   useState,
+  type ContextType,
 } from "react";
 import { z } from "zod";
 

--- a/src/hooks/useChatCommand.ts
+++ b/src/hooks/useChatCommand.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
-import tmi, { ChatUserstate } from "tmi.js";
+import tmi, { type ChatUserstate } from "tmi.js";
 
 import { typeSafeObjectEntries } from "../utils/helpers";
 

--- a/src/pages/overlay/components/Buttons.tsx
+++ b/src/pages/overlay/components/Buttons.tsx
@@ -52,7 +52,7 @@ export default function Buttons<T extends ButtonsOptions = ButtonsOptions>(
               option.active && "outline-3",
               // If the previous type is not the same, add a margin
               idx > 0 &&
-                optionsWithOnClick[idx - 1].type !== option.type &&
+                optionsWithOnClick[idx - 1]!.type !== option.type &&
                 "mt-auto",
             )}
           >

--- a/src/pages/overlay/hooks/useSettings.tsx
+++ b/src/pages/overlay/hooks/useSettings.tsx
@@ -12,7 +12,10 @@ import {
   typeSafeObjectEntries,
   typeSafeObjectFromEntries,
 } from "../../../utils/helpers";
-import { OverlayKey, isValidOverlayKey } from "../components/overlay/Overlay";
+import {
+  isValidOverlayKey,
+  type OverlayKey,
+} from "../components/overlay/Overlay";
 
 const settings = {
   disableChatPopup: {

--- a/src/utils/dateManager.ts
+++ b/src/utils/dateManager.ts
@@ -124,9 +124,9 @@ export function isBirthday(dateOfBirth: string): boolean {
  */
 function parseDate(date: string): Date | null {
   const dateArray = date.split("-");
-  const day = parseInt(dateArray[2]);
-  const month = parseInt(dateArray[1]);
-  const year = parseInt(dateArray[0]);
+  const day = parseInt(dateArray[2] ?? "");
+  const month = parseInt(dateArray[1] ?? "");
+  const year = parseInt(dateArray[0] ?? "");
 
   if (!isNaN(day) && !isNaN(month) && !isNaN(year))
     return new Date(year, month - 1, day);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,10 +19,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs"
-    }
-  }
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,6 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "erasableSyntaxOnly": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -20,9 +17,7 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "ts-node": {
     "compilerOptions": {
       "module": "commonjs"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
     "module": "esnext",


### PR DESCRIPTION
In a similar vein to https://github.com/alveusgg/alveusgg/pull/1063, this enables `erasableSyntaxOnly` now that we have TS 5.8, and then also enables `verbatimModuleSyntax` which works alongside it to make sure type imports are marked as such. Also enables `noUncheckedIndexedAccess` as we had that enabled in alveusgg/alveusgg but not here.