### PR TITLE
Make ambassador API parsing more resilient to bad data

### DIFF
--- a/src/hooks/useAmbassadors.tsx
+++ b/src/hooks/useAmbassadors.tsx
@@ -38,10 +38,11 @@ const apiAmbassadorSchema = ambassadorSchema.extend({
       title: z.string(),
     }),
     class: z.object({
-      name: speciesSchema.shape.class,
+      name: z.string(),
       title: z.string(),
     }),
   }),
+  enclosure: z.string(),
 });
 
 type Ambassador = z.infer<typeof apiAmbassadorSchema>;


### PR DESCRIPTION
- Install version 0.54.0 of the data package, which lacks the new species/enclosure types from https://github.com/alveusgg/data/pull/127
- Observe new ambassadors still show in extension
- `git reset --hard HEAD~1` locally to remove the generic types fix
- Observe new ambassadors logged as parse failures
- Observe API ambassador data/images still used for remaining ambassadors