### PR TITLE
Use Alveus timezone for birthday/age logic

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS=abdullahmorrison,mattipv4,pjeweb,alveus
 REACT_APP_DEFAULT_CHANNEL_NAMES=maya,alveussanctuary
 REACT_APP_EXTRA_CHANNEL_NAMES=alveusgg
 REACT_APP_API_BASE_URL=https://ext.alveussanctuary.org
+REACT_APP_TIMEZONE=America/Chicago

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@alveusgg/data": "0.55.1",
     "@headlessui/react": "^2.2.0",
+    "luxon": "^3.6.0",
     "react": "^19.0.0",
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.0.0",
@@ -43,6 +44,7 @@
     "@tailwindcss/postcss": "^4.0.17",
     "@types/canvas-confetti": "^1.9.0",
     "@types/eslint-config-prettier": "^6.11.3",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^22.13.13",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      luxon:
+        specifier: ^3.6.0
+        version: 3.6.0
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -46,6 +49,9 @@ importers:
       '@types/eslint-config-prettier':
         specifier: ^6.11.3
         version: 6.11.3
+      '@types/luxon':
+        specifier: ^3.4.2
+        version: 3.4.2
       '@types/node':
         specifier: ^22.13.13
         version: 22.13.13
@@ -163,6 +169,9 @@ packages:
     peerDependencies:
       tailwindcss: ^4.0.0
       zod: ^3.0.0
+    peerDependenciesMeta:
+      tailwindcss:
+        optional: true
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -647,6 +656,9 @@ packages:
 
   '@types/loader-utils@2.0.6':
     resolution: {integrity: sha512-cgu0Xefgq9O5FjFR78jgI6X31aPjDWCaJ6LCfRtlj6BtyVVWiXagysSYlPACwGKAzRwsFLjKXcj4iGfcVt6cLw==}
+
+  '@types/luxon@3.4.2':
+    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -2161,6 +2173,10 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  luxon@3.6.0:
+    resolution: {integrity: sha512-WE7p0p7W1xji9qxkLYsvcIxZyfP48GuFrWIBQZIsbjCyf65dG1rv4n83HcOyEyhvzxJCrUoObCRNFgRNIQ5KNA==}
+    engines: {node: '>=12'}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -3330,8 +3346,9 @@ snapshots:
 
   '@alveusgg/data@0.55.1(tailwindcss@4.0.17)(zod@3.24.2)':
     dependencies:
-      tailwindcss: 4.0.17
       zod: 3.24.2
+    optionalDependencies:
+      tailwindcss: 4.0.17
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -3789,6 +3806,8 @@ snapshots:
     dependencies:
       '@types/node': 22.13.13
       '@types/webpack': 4.41.40
+
+  '@types/luxon@3.4.2': {}
 
   '@types/mime@1.3.5': {}
 
@@ -5503,6 +5522,8 @@ snapshots:
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  luxon@3.6.0: {}
 
   make-error@1.3.6: {}
 

--- a/src/pages/overlay/components/overlay/Ambassadors.tsx
+++ b/src/pages/overlay/components/overlay/Ambassadors.tsx
@@ -13,7 +13,7 @@ import AmbassadorButton from "../../../../components/AmbassadorButton";
 import { useAmbassadors } from "../../../../hooks/useAmbassadors";
 import { classes } from "../../../../utils/classes";
 import { typeSafeObjectEntries } from "../../../../utils/helpers";
-import { sortDate } from "../../../../utils/dateManager";
+import { sortPartialDates } from "../../../../utils/dateManager";
 
 import type { OverlayOptionProps } from "./Overlay";
 
@@ -44,7 +44,7 @@ export default function Ambassadors(props: AmbassadorsProps) {
           ([, ambassador]) =>
             (ambassador.species.class.name === "plantae") === plants,
         )
-        .sort(([, a], [, b]) => sortDate(a.arrival, b.arrival)),
+        .sort(([, a], [, b]) => sortPartialDates(a.arrival, b.arrival)),
     [rawAmbassadors, plants],
   );
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -10,6 +10,7 @@ declare namespace NodeJS {
     readonly REACT_APP_EXTRA_CHANNEL_NAMES?: string;
     readonly REACT_APP_TEST_CHANNEL_NAMES?: string;
     readonly REACT_APP_API_BASE_URL?: string;
+    readonly REACT_APP_TIMEZONE?: string;
   };
 }
 

--- a/src/utils/dateManager.ts
+++ b/src/utils/dateManager.ts
@@ -1,3 +1,28 @@
+import { DateTime } from "luxon";
+
+const timezone = process.env.REACT_APP_TIMEZONE || "UTC";
+
+const getToday = () => DateTime.now().setZone(timezone).startOf("day");
+
+type PartialDate =
+  | `${number}`
+  | `${number}-${number}`
+  | `${number}-${number}-${number}`;
+
+const splitPartialDate = (partialDate: PartialDate) =>
+  partialDate.split("-").map((x) => parseInt(x)) as
+    | [number]
+    | [number, number]
+    | [number, number, number];
+
+export const isBirthday = (dateOfBirth: PartialDate) => {
+  const [, month, day] = splitPartialDate(dateOfBirth);
+  if (month === undefined || day === undefined) return false;
+
+  const today = getToday();
+  return today.month === month && today.day === day;
+};
+
 /**
  * calculates the age of the ambassador based on the date of birth
  * in weeks, months, or years
@@ -102,18 +127,6 @@ function getDaySuffix(day: number): string {
   else if (day === 2 || day === 22) return "nd";
   else if (day === 3 || day === 23) return "rd";
   else return "th";
-}
-
-export function isBirthday(dateOfBirth: string): boolean {
-  if (dateOfBirth.split("-").length !== 3) return false;
-
-  const today = new Date();
-  const dob = new Date(dateOfBirth);
-
-  return (
-    today.getUTCMonth() === dob.getUTCMonth() &&
-    today.getUTCDate() === dob.getUTCDate()
-  );
 }
 
 /**

--- a/src/utils/dateManager.ts
+++ b/src/utils/dateManager.ts
@@ -78,39 +78,15 @@ export const formatDate = (date: PartialDate, showApproximate = true) => {
   return `${showApproximate ? "~" : ""}${year}`;
 };
 
-/**
- * Parse a partial date string into a Date object
- *
- * @param {string} date partial date to parse (e.g. 2023 or 2023-01 or 2023-01-01)
- * @returns {Date|null} Date object if the date is valid, null otherwise
- */
-function parseDate(date: string): Date | null {
-  const dateArray = date.split("-");
-  const day = parseInt(dateArray[2] ?? "");
-  const month = parseInt(dateArray[1] ?? "");
-  const year = parseInt(dateArray[0] ?? "");
-
-  if (!isNaN(day) && !isNaN(month) && !isNaN(year))
-    return new Date(year, month - 1, day);
-  else if (!isNaN(month) && !isNaN(year)) return new Date(year, month - 1);
-  else if (!isNaN(year)) return new Date(year);
-
-  return null;
-}
-
-/**
- * Sorts the dates in descending order, with nulls at the end
- *
- * @param {string|null} a first date to compare
- * @param {string|null} b second date to compare
- * @returns {number}
- */
-export function sortDate(a: string | null, b: string | null): number {
-  const parsedA = typeof a === "string" ? parseDate(a) : null;
-  const parsedB = typeof b === "string" ? parseDate(b) : null;
+export const sortPartialDates = (
+  a: PartialDate | null,
+  b: PartialDate | null,
+) => {
+  const parsedA = typeof a === "string" ? parsePartialDate(a).toMillis() : null;
+  const parsedB = typeof b === "string" ? parsePartialDate(b).toMillis() : null;
 
   if (parsedA === parsedB) return 0;
   else if (parsedA === null || (parsedB !== null && parsedB > parsedA))
     return 1;
   else return -1;
-}
+};

--- a/src/utils/dateManager.ts
+++ b/src/utils/dateManager.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { DateTime, Info } from "luxon";
 
 const timezone = process.env.REACT_APP_TIMEZONE || "UTC";
 
@@ -50,68 +50,33 @@ export const calculateAge = (dateOfBirth: PartialDate) => {
   return `${accurate ? "" : "~"}${floorDays} day${floorDays === 1 ? "" : "s"}`;
 };
 
-/**
- * converts a date to a string of the date in the format Month DD, YYYY or Month YYYY or YYYY
- * @param date date in the format YYYY-MM-DD or YYYY-MM or YYYY
- * @returns a string of the date in the format Month DD, YYYY or Month YYYY or YYYY
- */
-export function formatDate(date: string, approximate = true): string {
-  const dateArray = date.split("-");
-  let day = dateArray[2];
-  let month = dateArray[1];
-  const year = dateArray[0];
+const getMonthName = (month: number) => {
+  if (month < 1 || month > 12) throw new Error("Invalid month");
+  return Info.months("long")[month - 1];
+};
 
-  if (month && day) {
-    month = monthConverter(parseInt(month));
-    day = parseInt(day) + getDaySuffix(parseInt(day));
-  } else if (month) {
-    month = monthConverter(parseInt(month));
-  }
+const getOrdinal = (number: number) => {
+  if (number < 1) throw new Error("Invalid number");
+  const lastDigit = number % 10;
+  const lastTwoDigits = number % 100;
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) return "th";
+  if (lastDigit === 1) return "st";
+  if (lastDigit === 2) return "nd";
+  if (lastDigit === 3) return "rd";
+  return "th";
+};
 
-  if (day && month && year) return `${month} ${day}, ${year}`;
-  else if (month && year) return `${approximate ? "~" : ""}${month}, ${year}`;
+export const formatDate = (date: PartialDate, showApproximate = true) => {
+  const [year, month, day] = splitPartialDate(date);
 
-  return `${approximate ? "~" : ""}${year}`;
-}
+  const formattedMonth = month && getMonthName(month);
+  const formattedDay = day && `${day}${getOrdinal(day)}`;
 
-/**
- * converts the numerical month to the name of the month
- * @param month month number (1-12)
- * @returns the name corresponding to the month number
- */
-function monthConverter(month: number) {
-  const monthNames = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
-
-  if (month < 0 || month > 12) return "Invalid month";
-
-  return monthNames[month - 1];
-}
-
-/**
- * @param day day of the month (1-31)
- * @returns the suffix of the day (st, nd, rd, or th)
- */
-function getDaySuffix(day: number): string {
-  if (day < 1 || day > 31) return "";
-
-  if (day === 1 || day === 21 || day === 31) return "st";
-  else if (day === 2 || day === 22) return "nd";
-  else if (day === 3 || day === 23) return "rd";
-  else return "th";
-}
+  if (day && month && year) return `${formattedMonth} ${formattedDay}, ${year}`;
+  if (month && year)
+    return `${showApproximate ? "~" : ""}${formattedMonth}, ${year}`;
+  return `${showApproximate ? "~" : ""}${year}`;
+};
 
 /**
  * Parse a partial date string into a Date object


### PR DESCRIPTION
It seems a bit odd that ambassadors show their birthday as soon as midnight UTC is hit. It also felt weird to make it work based on local time (where APAC users would see ambassador birthdays the day before essentially). So, using Alveus' timezone seems like the right option but doing timezone logic in native JS is awful so I've introduced Luxon to handle it as we do on the website.