### PR TITLE
Joshua mae/refresh command

### DIFF
--- a/src/hooks/useAmbassadors.tsx
+++ b/src/hooks/useAmbassadors.tsx
@@ -164,7 +164,6 @@ export const AmbassadorsProvider = ({
     fetchAmbassadors()
       .then(setAmbassadors)
       .catch((err) => console.error(err));
-    console.log("Ambassadors refreshed, it has made it to the end");
   }, []);
 
   // Every 2 hours, attempt to fetch the ambassadors from the API

--- a/src/hooks/useChatCommand.ts
+++ b/src/hooks/useChatCommand.ts
@@ -21,7 +21,9 @@ const privilegedUsers = parseCsvEnv(
   process.env.REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS,
 );
 
-export default function useChatCommand(callback: (command: string) => void) {
+export default function useChatCommand(
+  callback: (command: string, isPrivileged?: boolean) => void,
+) {
   const channel = useChannel();
   const channelNames = useMemo(
     () =>
@@ -84,7 +86,12 @@ export default function useChatCommand(callback: (command: string) => void) {
         `*Twitch extension received command: ${commandName} (${command})*`,
         id,
       );
-      if (command) callback(command);
+      if (command) {
+        const isPrivileged = privilegedUsers.includes(
+          tags.username?.toLowerCase() ?? "",
+        );
+        callback(command, isPrivileged);
+      }
     },
     [commandsMap, callback],
   );

--- a/src/hooks/useChatCommand.ts
+++ b/src/hooks/useChatCommand.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import tmi, { type ChatUserstate } from "tmi.js";
 
 import { typeSafeObjectEntries } from "../utils/helpers";
@@ -21,9 +21,7 @@ const privilegedUsers = parseCsvEnv(
   process.env.REACT_APP_CHAT_COMMANDS_PRIVILEGED_USERS,
 );
 
-export default function useChatCommand(
-  callback: (command: string, isPrivileged?: boolean) => void,
-) {
+export default function useChatCommand(callback: (command: string) => void) {
   const channel = useChannel();
   const channelNames = useMemo(
     () =>
@@ -48,8 +46,6 @@ export default function useChatCommand(
   );
 
   const ambassadors = useAmbassadors();
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
   const commandsMap = useMemo(() => {
     const commands = new Map<string, string>();
     if (ambassadors) {
@@ -88,14 +84,9 @@ export default function useChatCommand(
         `*Twitch extension received command: ${commandName} (${command})*`,
         id,
       );
-      if (command) {
-        const isPrivileged = privilegedUsers.includes(
-          tags.username?.toLowerCase() ?? "",
-        );
-        callback(command, isPrivileged);
-      }
+      if (command) callback(command);
     },
-    [commandsMap],
+    [commandsMap, callback],
   );
 
   useEffect(() => {
@@ -148,5 +139,5 @@ export default function useChatCommand(
           console.log("*Twitch extension disconnected from chat*", id),
         );
     };
-  }, [channelNames]);
+  }, [channelNames, messageHandler]);
 }

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -153,20 +153,7 @@ export default function Overlay() {
           const ambassador = ambassadors?.[command];
           if (ambassador)
             setActiveAmbassador({ key: command, isCommand: true });
-          else if (command === "refresh" && isPrivileged) {
-            refreshAmbassadors().then(() => {
-              setActiveAmbassador({});
-              setVisibleOption("welcome");
-              const ambassadorLists = document.querySelectorAll(".list-fade");
-              ambassadorLists.forEach((list) => {
-                list.scrollTo({
-                  top: 0,
-                  behavior: "smooth",
-                });
-              });
-            });
-            return;
-          } else if (command !== "welcome") return;
+          else if (command !== "welcome") return;
 
           // Show the card
           setVisibleOption(
@@ -188,8 +175,23 @@ export default function Overlay() {
           awakingRef.current = true;
           wake(commandTimeout);
         }
+
+        // Ignore chat popup preference, the refresh should always go through and show if called
+        if (command === "refresh" && isPrivileged) {
+          refreshAmbassadors().then(() => {
+            setActiveAmbassador({});
+            setVisibleOption("welcome");
+            const ambassadorLists = document.querySelectorAll(".list-fade");
+            ambassadorLists.forEach((list) => {
+              list.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              });
+            });
+          });
+        }
       },
-      [settings.disableChatPopup.value, ambassadors, wake],
+      [settings.disableChatPopup.value, ambassadors, wake, refreshAmbassadors],
     ),
   );
 

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -154,16 +154,18 @@ export default function Overlay() {
           if (ambassador)
             setActiveAmbassador({ key: command, isCommand: true });
           else if (command === "refresh" && isPrivileged) {
-            refreshAmbassadors();
-            setActiveAmbassador({});
-            setVisibleOption("");
-            const ambassadorLists = document.querySelectorAll(".list-fade");
-            ambassadorLists.forEach((list) => {
-              list.scrollTo({
-                top: 0,
-                behavior: "smooth",
+            refreshAmbassadors().then(() => {
+              setActiveAmbassador({});
+              setVisibleOption("welcome");
+              const ambassadorLists = document.querySelectorAll(".list-fade");
+              ambassadorLists.forEach((list) => {
+                list.scrollTo({
+                  top: 0,
+                  behavior: "smooth",
+                });
               });
             });
+            return;
           } else if (command !== "welcome") return;
 
           // Show the card

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -15,7 +15,10 @@ import IconAmbassadors from "../../../../components/icons/IconAmbassadors";
 import IconPlant from "../../../../components/icons/IconPlant";
 import IconSettings from "../../../../components/icons/IconSettings";
 
-import { useAmbassadors } from "../../../../hooks/useAmbassadors";
+import {
+  useAmbassadors,
+  useRefreshAmbassadors,
+} from "../../../../hooks/useAmbassadors";
 import { classes } from "../../../../utils/classes";
 import { visibleUnderCursor } from "../../../../utils/dom";
 
@@ -114,6 +117,7 @@ export default function Overlay() {
   } = useSleeping();
 
   const ambassadors = useAmbassadors();
+  const refreshAmbassadors = useRefreshAmbassadors();
   const options = useMemo(
     () =>
       overlayOptions.filter(
@@ -144,12 +148,23 @@ export default function Overlay() {
   // When a chat command is run, wake the overlay
   useChatCommand(
     useCallback(
-      (command: string) => {
+      (command: string, isPrivileged?: boolean) => {
         if (!settings.disableChatPopup.value) {
           const ambassador = ambassadors?.[command];
           if (ambassador)
             setActiveAmbassador({ key: command, isCommand: true });
-          else if (command !== "welcome") return;
+          else if (command === "refresh" && isPrivileged) {
+            refreshAmbassadors();
+            setActiveAmbassador({});
+            setVisibleOption("");
+            const ambassadorLists = document.querySelectorAll(".list-fade");
+            ambassadorLists.forEach((list) => {
+              list.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              });
+            });
+          } else if (command !== "welcome") return;
 
           // Show the card
           setVisibleOption(

--- a/src/pages/panel/components/Ambassadors.tsx
+++ b/src/pages/panel/components/Ambassadors.tsx
@@ -3,7 +3,10 @@ import { useState, useCallback, Fragment, useMemo } from "react";
 import AmbassadorCard from "../../../components/AmbassadorCard";
 import AmbassadorButton from "../../../components/AmbassadorButton";
 
-import { useAmbassadors } from "../../../hooks/useAmbassadors";
+import {
+  useAmbassadors,
+  useRefreshAmbassadors,
+} from "../../../hooks/useAmbassadors";
 
 import useChatCommand from "../../../hooks/useChatCommand";
 import { typeSafeObjectEntries } from "../../../utils/helpers";
@@ -12,6 +15,7 @@ import Overlay from "./Overlay";
 
 export default function Ambassadors() {
   const rawAmbassadors = useAmbassadors();
+  const refreshAmbassadors = useRefreshAmbassadors();
   const ambassadors = useMemo(
     () => typeSafeObjectEntries(rawAmbassadors ?? {}),
     [rawAmbassadors],
@@ -21,11 +25,23 @@ export default function Ambassadors() {
   const [ambassadorCard, setAmbassadorCard] = useState<string>();
   useChatCommand(
     useCallback(
-      (command: string) => {
+      (command: string, isPrivileged?: boolean) => {
+        if (isPrivileged && command === "refresh") {
+          refreshAmbassadors().then(() => {
+            setAmbassadorCard(undefined);
+            const ambassadorLists = document.querySelectorAll(".scrollbar");
+            ambassadorLists.forEach((list) => {
+              list.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              });
+            });
+          });
+        }
         if (Object.keys(rawAmbassadors ?? {}).includes(command))
           setAmbassadorCard(command);
       },
-      [rawAmbassadors],
+      [rawAmbassadors, refreshAmbassadors],
     ),
   );
 


### PR DESCRIPTION
Resolves #358 

- Added `!refresh` functionality for both panel and overlay with a random 1-120s delay to spread out the requests
- `!refresh` fetches new data, alters the user's ambassador selection, scroll location, brings them back to the welcome message, and even overrides their settings preference to make it look like a refresh happened (I am open to a less intrusive refresh if this is too much)
