### PR TITLE
Ensure effects setting is cast to boolean (+ use sentence-case for settings)

### DIFF
--- a/src/pages/overlay/hooks/useSettings.tsx
+++ b/src/pages/overlay/hooks/useSettings.tsx
@@ -19,13 +19,13 @@ import {
 
 const settings = {
   disableChatPopup: {
-    title: "Prevent Mod-triggered Card Popups",
+    title: "Prevent mod-triggered card pop-ups",
     type: "boolean",
     process: (value: any) => !!value,
     configurable: true,
   },
   disableCardEffects: {
-    title: "Disable Ambassador Card Effects",
+    title: "Disable ambassador card effects",
     type: "boolean",
     process: (value: any) =>
       !!(

--- a/src/pages/overlay/hooks/useSettings.tsx
+++ b/src/pages/overlay/hooks/useSettings.tsx
@@ -28,7 +28,9 @@ const settings = {
     title: "Disable Ambassador Card Effects",
     type: "boolean",
     process: (value: any) =>
-      value ?? window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      !!(
+        value ?? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ),
     configurable: true,
   },
   disableOverlayHiding: {


### PR DESCRIPTION
Quick follow-up fix for #362 to ensure the new setting added is always cast to a boolean, and a change to all our settings to consistently use sentence-case for them.