### PR TITLE
Bump pnpm from 10.29.1 to 10.29.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^10.29.1"
+    "pnpm": "^10.29.3"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@10.29.3",
   "scripts": {
     "prepare": "husky",
     "dev": "cross-env NODE_ENV=development NODE_OPTIONS=\"--loader ts-node/esm\" webpack serve",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/extension/actions/runs/22046218758.