### PR TITLE
Bump pnpm from 10.31.0 to 10.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^10.31.0"
+    "pnpm": "^10.32.1"
   },
-  "packageManager": "pnpm@10.31.0",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "prepare": "husky",
     "dev": "cross-env NODE_ENV=development NODE_OPTIONS=\"--loader ts-node/esm\" webpack serve",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/extension/actions/runs/22977277614.