### PR TITLE
Add bottom margin to TiltCard when card effects are enabled

### DIFF
--- a/src/components/AmbassadorCard.tsx
+++ b/src/components/AmbassadorCard.tsx
@@ -127,6 +127,7 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
       disabled={disableCardEffects}
       className={classes(
         "relative flex max-h-full min-h-[min(28rem,100%)] w-80 max-w-full flex-col rounded-lg bg-alveus-green-900 text-xs shadow-xl",
+        !disableCardEffects && "mb-10",
         className,
       )}
       ref={callbackRef}

--- a/src/components/AmbassadorCard.tsx
+++ b/src/components/AmbassadorCard.tsx
@@ -127,7 +127,7 @@ export default function AmbassadorCard(props: AmbassadorCardProps) {
       disabled={disableCardEffects}
       className={classes(
         "relative flex max-h-full min-h-[min(28rem,100%)] w-80 max-w-full flex-col rounded-lg bg-alveus-green-900 text-xs shadow-xl",
-        !disableCardEffects && "mb-10",
+        !disableCardEffects && "mb-4",
         className,
       )}
       ref={callbackRef}


### PR DESCRIPTION
I'm having trouble getting obs or the ffmpeg script to kick off a livestream, but this is the place to add mb-x to add space above where the progress bar would be. #480 

Commenting/uncommenting the added line: 

https://github.com/user-attachments/assets/fa30e913-de1f-4e08-9dd7-0c5f3e91ddd0

