### PR TITLE
Bump pnpm from 11.5.2 to 11.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^11.5.2"
+    "pnpm": "^11.6.0"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.6.0",
   "scripts": {
     "prepare": "husky",
     "dev": "webpack serve",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/extension/actions/runs/27518245562.